### PR TITLE
Fix missing dataclass for processed images

### DIFF
--- a/src/core/domain_models.py
+++ b/src/core/domain_models.py
@@ -54,6 +54,18 @@ class EmailResponse:
             self.attachments = []
 
 
+@dataclass
+class ProcessedImage:
+    """Represents an image processed by the service."""
+
+    image_path: str
+    width: int
+    height: int
+    original_filename: str
+    content_type: str
+    scaled_content: bytes
+
+
 class ValidationError:
     """Represents a validation error with context."""
     


### PR DESCRIPTION
## Summary
- define `ProcessedImage` dataclass which was missing in `core.domain_models`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68420564591483229687fe28814cc4ab