### PR TITLE
Fix version mismatch in health endpoints

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -9,8 +9,12 @@ from fastapi import FastAPI, HTTPException, Request, Query, Depends
 from fastapi.responses import JSONResponse
 from typing import Optional
 
+from .. import __version__
+
 from ..core.configuration import config
 from .webhook_handler import WebhookHandler
+
+APP_VERSION = __version__
 
 
 # Configure logging
@@ -21,7 +25,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(
     title="Prof. Warlock",
     description="Natal Chart Poster Generator via Email",
-    version="1.0.0",
+    version=APP_VERSION,
     docs_url="/docs",
     redoc_url="/redoc"
 )
@@ -57,7 +61,7 @@ async def health_check():
     return {
         "message": "Prof. Warlock is running!",
         "status": "healthy",
-        "version": "2.0.0"
+        "version": APP_VERSION
     }
 
 
@@ -67,7 +71,7 @@ async def detailed_health_check():
     return {
         "status": "healthy",
         "service": "Prof. Warlock",
-        "version": "1.0.0",
+        "version": APP_VERSION,
         "features": [
             "email_parsing",
             "image_processing",


### PR DESCRIPTION
## Summary
- reference app version from a single constant in `main.py`
- use that constant in both `/` and `/health` responses

## Testing
- `pytest -k 'health_check' -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68420c23f89483229f8af772890cd295