### PR TITLE
Replace symlink with module for ImageAnnotator

### DIFF
--- a/src/services/image_annotation_lib.py
+++ b/src/services/image_annotation_lib.py
@@ -1,1 +1,6 @@
-image_annotation_lib.py
+"""Compatibility wrapper for the image annotation library."""
+
+from .image_annotation import ImageAnnotator
+
+__all__ = ["ImageAnnotator"]
+


### PR DESCRIPTION
## Summary
- remove the self-referencing symlink `image_annotation_lib.py`
- replace it with a regular module exporting `ImageAnnotator` from `image_annotation`

## Testing
- `pip install -q -r requirements.txt` *(fails: network access required)*
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68420c1401f4832299c15f7416c0226c