### PR TITLE
Fix leftover Prof. Postmark references

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 """
-Prof. Postmark Application Entry Point
+Prof. Warlock Application Entry Point
 
 Clean entry point for running the FastAPI application.
 """

--- a/env.sample
+++ b/env.sample
@@ -1,4 +1,4 @@
-# Prof. Postmark Environment Sample
+# Prof. Warlock Environment Sample
 POSTMARK_API_KEY=your-postmark-server-token-here
 DOMAIN=yourdomain.com
 FROM_EMAIL=prof@yourdomain.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Prof. Postmark - Async Email Feedback System
+# Prof. Warlock - Natal Chart Generator via Email
 fastapi==0.104.1
 uvicorn==0.24.0
 python-multipart==0.0.6

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,8 +1,8 @@
 """
-Prof. Postmark - Async Email Feedback System
+Prof. Warlock - Natal Chart Generator via Email
 
-A clean, modular email-based feedback system using AI.
+A magical email-driven service that creates personalized natal chart posters.
 """
 
 __version__ = "2.0.0"
-__author__ = "Prof. Postmark Team" 
+__author__ = "Prof. Warlock Team"

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,3 +1,3 @@
 """
-FastAPI web API for Prof. Postmark.
-""" 
+FastAPI web API for Prof. Warlock.
+"""

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,5 +1,5 @@
 """
-FastAPI application for Prof. Postmark.
+FastAPI application for Prof. Warlock.
 
 Clean, focused API with proper error handling and security.
 """

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,3 +1,3 @@
 """
-Core domain models and configuration for Prof. Postmark.
-""" 
+Core domain models and configuration for Prof. Warlock.
+"""

--- a/src/core/domain_models.py
+++ b/src/core/domain_models.py
@@ -1,5 +1,5 @@
 """
-Domain models for Prof. Postmark.
+Domain models for Prof. Warlock.
 
 Clean representation of core business entities.
 """

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,3 +1,3 @@
 """
-Business logic services for Prof. Postmark.
-""" 
+Business logic services for Prof. Warlock.
+"""

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -1,3 +1,3 @@
 """
-Test suite for Prof. Postmark.
-""" 
+Test suite for Prof. Warlock.
+"""


### PR DESCRIPTION
## Summary
- update module docstrings to use **Prof. Warlock** branding
- update requirements and environment sample comments
- remove stale references

## Testing
- `pytest -q` *(fails: No module named 'natal')*

------
https://chatgpt.com/codex/tasks/task_e_68420c09d88c8322970a951efbc79051